### PR TITLE
Fix chat overlap and clean typewriter rendering

### DIFF
--- a/style.css
+++ b/style.css
@@ -42,6 +42,16 @@ body {
   margin-bottom: 0;
 }
 
+@media (min-width: 1024px) {
+  .page-shell {
+    padding-right: 440px;
+  }
+
+  .intro {
+    max-width: 540px;
+  }
+}
+
 .chat-widget {
   position: fixed;
   bottom: 24px;
@@ -114,6 +124,28 @@ body {
   border: 2px solid var(--pink);
   align-self: flex-start;
   color: var(--navy);
+}
+
+.message.bot.typing::after {
+  content: '';
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  width: 2px;
+  height: 18px;
+  background: var(--pink);
+  animation: caretBlink 0.9s steps(1, end) infinite;
+}
+
+@keyframes caretBlink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  51%,
+  100% {
+    opacity: 0;
+  }
 }
 
 .message.user {


### PR DESCRIPTION
## Summary
- add wide-screen padding so the intro copy no longer hides behind the enlarged chat widget
- trim bot message HTML before typing and normalize whitespace nodes while rendering
- retain inline spacing only where needed so markup animates without extra blank lines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97aaff4c0832cba22ea628a698e54