### PR TITLE
Remove bot typing caret animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -126,28 +126,6 @@ body {
   color: var(--navy);
 }
 
-.message.bot.typing::after {
-  content: '';
-  position: absolute;
-  right: 12px;
-  bottom: 12px;
-  width: 2px;
-  height: 18px;
-  background: var(--pink);
-  animation: caretBlink 0.9s steps(1, end) infinite;
-}
-
-@keyframes caretBlink {
-  0%,
-  50% {
-    opacity: 1;
-  }
-  51%,
-  100% {
-    opacity: 0;
-  }
-}
-
 .message.user {
   background: var(--navy);
   color: white;


### PR DESCRIPTION
## Summary
- remove the bot typing caret pseudo-element styling from the chat widget
- delete the unused caretBlink keyframes animation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d980f70ee0832c94df98697b1c9036