### PR TITLE
Switch date input to MM/DD/YYYY format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There is no build process or external dependency; the experience is pure HTML, C
 1. Click the quick replies to move through the scripted paths.
 2. Provide input when the text field appears:
    - Tracking numbers must be 8–22 alphanumeric characters.
-   - Expected delivery dates are entered as `YYYY-MM-DD` and must be in the past.
+   - Expected delivery dates are entered as `MM/DD/YYYY` and must be in the past.
    - Damage descriptions should include at least ten characters.
 3. Choose “Talk to an agent” at any time to trigger the mock handoff response, or “Restart” to begin again from the top.
 

--- a/script.js
+++ b/script.js
@@ -154,26 +154,50 @@ const steps = {
   askExpectedDate: {
     onEnter() {
       botSay(
-        'I can start an investigation. When was the package supposed to arrive? (YYYY-MM-DD)'
+        'I can start an investigation. When was the package supposed to arrive? (MM/DD/YYYY)'
       );
       showTextInput({
         label: 'Expected delivery date',
-        placeholder: '2024-03-22',
-        hint: 'Use YYYY-MM-DD and choose a past date.',
+        placeholder: '03/22/2024',
+        hint: 'Use MM/DD/YYYY and choose a past date.',
       });
     },
     onInput(value) {
       const trimmed = value.trim();
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
-        botSay('Please use the YYYY-MM-DD format.');
-        inputHint.textContent = 'Example: 2024-03-22';
+      if (!/^\d{2}\/\d{2}\/\d{4}$/.test(trimmed)) {
+        botSay('Please use the MM/DD/YYYY format.');
+        inputHint.textContent = 'Example: 03/22/2024';
         return { stay: true };
       }
-      const entered = new Date(trimmed);
+      const [monthStr, dayStr, yearStr] = trimmed.split('/');
+      const month = Number.parseInt(monthStr, 10);
+      const day = Number.parseInt(dayStr, 10);
+      const year = Number.parseInt(yearStr, 10);
+      if (
+        Number.isNaN(day) ||
+        Number.isNaN(month) ||
+        Number.isNaN(year)
+      ) {
+        botSay('That date does not seem valid. Try again using MM/DD/YYYY.');
+        inputHint.textContent = 'Example: 03/22/2024';
+        return { stay: true };
+      }
+      const entered = new Date(year, month - 1, day);
+      entered.setHours(0, 0, 0, 0);
+      if (
+        entered.getFullYear() !== year ||
+        entered.getMonth() !== month - 1 ||
+        entered.getDate() !== day
+      ) {
+        botSay('That date does not seem valid. Try again using MM/DD/YYYY.');
+        inputHint.textContent = 'Example: 03/22/2024';
+        return { stay: true };
+      }
       const today = new Date();
       today.setHours(0, 0, 0, 0);
       if (Number.isNaN(entered.getTime())) {
-        botSay('That date does not seem valid. Try again using YYYY-MM-DD.');
+        botSay('That date does not seem valid. Try again using MM/DD/YYYY.');
+        inputHint.textContent = 'Example: 03/22/2024';
         return { stay: true };
       }
       if (entered > today) {


### PR DESCRIPTION
## Summary
- update the missing-package investigation prompt to request expected delivery dates in MM/DD/YYYY format
- adjust parsing and validation to interpret MM/DD/YYYY entries before accepting them
- refresh the README instructions to describe the MM/DD/YYYY requirement

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d9815016d8832cac85eccef3b4fd7d