### PR TITLE
Delay bot bubbles until typing starts

### DIFF
--- a/script.js
+++ b/script.js
@@ -301,8 +301,6 @@ const steps = {
 function botSay(content) {
   const bubble = document.createElement('div');
   bubble.className = 'message bot typing';
-  chatBody.appendChild(bubble);
-  scrollToBottom();
 
   let html = Array.isArray(content) ? content.join('<br />') : content;
   if (typeof html === 'string') {
@@ -310,7 +308,11 @@ function botSay(content) {
   }
 
   typingQueue = typingQueue
-    .then(() => typewriterInto(bubble, html))
+    .then(() => {
+      chatBody.appendChild(bubble);
+      scrollToBottom();
+      return typewriterInto(bubble, html);
+    })
     .then(() => {
       bubble.classList.remove('typing');
       scrollToBottom();


### PR DESCRIPTION
## Summary
- wait to add new bot bubbles until their turn in the typing queue
- avoid prematurely showing an empty bubble when the bot sends consecutive messages

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d985145870832ca0665429dc301659