### PR TITLE
Make bot chat bubbles transparent

### DIFF
--- a/style.css
+++ b/style.css
@@ -120,8 +120,8 @@ body {
 }
 
 .message.bot {
-  background: #ffffff;
-  border: 2px solid var(--pink);
+  background: transparent;
+  border: none;
   align-self: flex-start;
   color: var(--navy);
 }


### PR DESCRIPTION
## Summary
- set bot message background to transparent so it matches the chat body gradient

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d98c48173c832c89658da51c623378