### PR TITLE
Make chat message bubbles blend with background

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,6 +107,7 @@ body {
   padding-bottom: 24px;
 }
 
+
 .message {
   max-width: 80%;
   padding: 12px 16px;
@@ -117,10 +118,11 @@ body {
   display: inline-flex;
   flex-direction: column;
   gap: 6px;
+  background: transparent;
 }
 
 .message.bot {
-  background: var(--pink-soft);
+  background: transparent;
   border: none;
   align-self: flex-start;
   color: var(--navy);
@@ -131,8 +133,8 @@ body {
 }
 
 .message.user {
-  background: var(--navy);
-  color: white;
+  background: transparent;
+  color: var(--navy);
   align-self: flex-end;
   border-bottom-right-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- make the chat message containers transparent so bubbles blend into the background

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d999787708832c96f71b00c0598e74