### PR TITLE
Flatten chat message styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,20 +107,23 @@ body {
   padding-bottom: 24px;
 }
 
+
 .message {
   max-width: 80%;
-  padding: 12px 16px;
-  border-radius: 16px;
+  padding: 0;
+  border-radius: 0;
   line-height: 1.4;
   font-size: 0.95rem;
   position: relative;
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
   gap: 6px;
+  background: none;
+  box-shadow: none;
 }
 
 .message.bot {
-  background: var(--pink-soft);
+  background: none;
   border: none;
   align-self: flex-start;
   color: var(--navy);
@@ -131,10 +134,10 @@ body {
 }
 
 .message.user {
-  background: var(--navy);
-  color: white;
+  background: none;
+  color: var(--navy);
   align-self: flex-end;
-  border-bottom-right-radius: 4px;
+  text-align: right;
 }
 
 .message strong {


### PR DESCRIPTION
## Summary
- remove padding and rounded corners from chat messages so they blend with the chat background
- ensure both bot and user messages render without visible bubble styling while keeping alignment intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d999787708832c96f71b00c0598e74