### PR TITLE
Use icon on chat send button

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,15 @@
             required
             aria-describedby="inputHint"
           />
-          <button type="submit" class="send-button">Send</button>
+          <button type="submit" class="send-button" aria-label="Send message">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M3.24 4.14a1 1 0 0 1 1.08-.14l16 7a1 1 0 0 1 0 1.82l-16 7A1 1 0 0 1 3 20V4a1 1 0 0 1 .24-.86Z"
+                fill="currentColor"
+              />
+            </svg>
+            <span class="sr-only">Send</span>
+          </button>
         </form>
         <p id="inputHint" class="input-hint" aria-live="assertive"></p>
       </footer>

--- a/style.css
+++ b/style.css
@@ -177,10 +177,17 @@ body {
   color: white;
   border: none;
   border-radius: 12px;
-  padding: 10px 16px;
-  font-size: 0.95rem;
+  padding: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   transition: background 0.2s ease;
+}
+
+.send-button svg {
+  width: 18px;
+  height: 18px;
 }
 
 .send-button:hover,


### PR DESCRIPTION
## Summary
- replace the text label on the chat send button with an accessible SVG icon
- adjust the send button styling so the icon is centered and sized consistently

## Testing
- not run (static UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d9a69249b8832c8f6531566e96820d